### PR TITLE
fix sysconfig environment var name

### DIFF
--- a/templates/etc/default/snmpd.RedHat.j2
+++ b/templates/etc/default/snmpd.RedHat.j2
@@ -2,4 +2,4 @@
 
 # snmpd command line options
 # '-f' is implicitly added by snmpd systemd unit file
-SNMPDOPTS="{{ snmp_logging_options }}"
+OPTIONS="{{ snmp_logging_options }}"


### PR DESCRIPTION
centos7 comes with the following uni file for snmpd

```
[Unit]
Description=Simple Network Management Protocol (SNMP) Daemon.
After=syslog.target network.target

[Service]
Type=notify
Environment=OPTIONS="-LS0-6d"
EnvironmentFile=-/etc/sysconfig/snmpd
ExecStart=/usr/sbin/snmpd $OPTIONS -f
ExecReload=/bin/kill -HUP $MAINPID

[Install]
WantedBy=multi-user.target
```

So we need to set `OPTIONS` to apply logging config.